### PR TITLE
fix: personalize practice tab greeting and recommendations

### DIFF
--- a/src/app/lessons/[id]/page.tsx
+++ b/src/app/lessons/[id]/page.tsx
@@ -974,47 +974,18 @@ export default function LessonDetailPage() {
     );
   }
   
-  // Show PreLessonBriefing before lesson starts (all lessons get a brief intro)
+  // Show PreLessonBriefing before lesson starts (all lessons get Sheikh briefing)
   if (!lessonStarted) {
-    // For lessons with ayahs, show the full AI-generated briefing
-    if (lessonAyahs.length > 0) {
-      return (
-        <div className="min-h-screen px-4 py-8">
-          <PreLessonBriefing
-            lessonTitle={lesson.title}
-            ayahs={lessonAyahs}
-            userLevel="beginner"
-            isReview={false}
-            onStart={() => setLessonStarted(true)}
-            onDismiss={() => setLessonStarted(true)}
-          />
-        </div>
-      );
-    }
-    // For alphabet/concept lessons without ayahs, show a simple intro card
     return (
-      <div className="min-h-screen px-4 py-8 flex items-center justify-center">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="max-w-md w-full liquid-glass-gold rounded-2xl p-8 text-center"
-        >
-          <div className="w-14 h-14 rounded-2xl bg-gold-500/20 flex items-center justify-center mx-auto mb-4">
-            <BookOpen className="w-7 h-7 text-gold-400" />
-          </div>
-          <h2 className="text-xl font-bold text-night-100 mb-2">{lesson.title}</h2>
-          <p className="text-night-400 text-sm mb-2">Unit {lesson.unit}: {lesson.unitTitle}</p>
-          <p className="text-night-300 text-sm mb-6 leading-relaxed">{lesson.description}</p>
-          <p className="text-night-500 text-xs mb-6">
-            ⏱ About {lesson.estimatedMinutes} minutes · {lesson.xpReward} XP
-          </p>
-          <button
-            onClick={() => setLessonStarted(true)}
-            className="liquid-btn py-3 px-8 text-lg w-full"
-          >
-            Bismillah, Let's Start
-          </button>
-        </motion.div>
+      <div className="min-h-screen px-4 py-8">
+        <PreLessonBriefing
+          lessonTitle={lesson.title}
+          ayahs={lessonAyahs.length > 0 ? lessonAyahs : undefined}
+          userLevel="beginner"
+          isReview={false}
+          onStart={() => setLessonStarted(true)}
+          onDismiss={() => setLessonStarted(true)}
+        />
       </div>
     );
   }

--- a/src/app/practice/page.tsx
+++ b/src/app/practice/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useRouter } from 'next/navigation';
 import { useCalibrationGuard } from '@/hooks/useCalibrationGuard';
@@ -66,6 +66,16 @@ export default function PracticePage() {
 
   const [isCalibrated, setIsCalibrated] = useState(true);
   const [completedLessons, setCompletedLessons] = useState<string[]>([]);
+
+  // Resolve display name: Clerk user → localStorage (onboarding) → fallback
+  const displayName = useMemo(() => {
+    if (user?.firstName) return user.firstName;
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('quranOasis_userName');
+      if (stored) return stored;
+    }
+    return 'Student';
+  }, [user]);
 
   // Load profile and SRS state
   useEffect(() => {
@@ -325,7 +335,7 @@ export default function PracticePage() {
         <div className="px-4 py-3 flex items-center justify-between">
           <div>
             <h1 className="font-display text-xl text-night-100">
-              {getGreeting()}, {user?.firstName || 'Student'}
+              {getGreeting()}, {displayName}
             </h1>
             <p className="text-sm text-night-500">
               {dueCount.total > 0

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -194,7 +194,7 @@ export default function ProfilePage() {
   }, []);
 
   // Get user info
-  const displayName = user?.firstName || 'Student of Quran';
+  const displayName = user?.firstName || (typeof window !== 'undefined' ? localStorage.getItem('quranOasis_userName') : null) || 'Student of Quran';
   const email = user?.emailAddresses?.[0]?.emailAddress;
   const avatarUrl = user?.imageUrl;
   const joinedDate = user?.createdAt 

--- a/src/components/PreLessonBriefing.tsx
+++ b/src/components/PreLessonBriefing.tsx
@@ -46,8 +46,8 @@ interface AyahInfo {
 interface PreLessonBriefingProps {
   /** Lesson title for display */
   lessonTitle: string;
-  /** Ayahs the student will study */
-  ayahs: AyahInfo[];
+  /** Ayahs the student will study (empty for alphabet/concept lessons) */
+  ayahs?: AyahInfo[];
   /** User's learning level */
   userLevel: 'beginner' | 'intermediate' | 'advanced';
   /** Whether this is a review lesson */
@@ -77,13 +77,13 @@ export default function PreLessonBriefing({
   const [dismissed, setDismissed] = useState(false);
   const [animateIn, setAnimateIn] = useState(false);
 
+  const safeAyahs = ayahs ?? [];
+
   // Generate briefing on mount
   useEffect(() => {
-    if (ayahs.length === 0) return;
-
     const ctx: BriefingContext = {
       lessonTitle,
-      ayahs,
+      ayahs: safeAyahs,
       userLevel,
       isReview,
     };
@@ -123,7 +123,7 @@ export default function PreLessonBriefing({
   };
 
   const handleLearnMore = () => {
-    const question = briefing
+    const question = briefing && safeAyahs.length > 0
       ? `Tell me more about ${lessonTitle} — what makes these ayahs special?`
       : `What should I know about ${lessonTitle} before I start?`;
     openSheikh(question);
@@ -210,8 +210,10 @@ export default function PreLessonBriefing({
       {/* ─── Styles ──────────────────────────────────────────────── */}
       <style jsx>{`
         .sheikh-briefing {
-          background: linear-gradient(135deg, #0c1f1a 0%, #132e25 50%, #1a3a2f 100%);
-          border: 1px solid rgba(45, 212, 150, 0.15);
+          background: rgba(255, 255, 255, 0.06);
+          backdrop-filter: blur(24px) saturate(1.4);
+          -webkit-backdrop-filter: blur(24px) saturate(1.4);
+          border: 1px solid rgba(255, 255, 255, 0.15);
           border-radius: 16px;
           padding: 20px;
           margin-bottom: 20px;
@@ -220,6 +222,7 @@ export default function PreLessonBriefing({
           transition: opacity 0.4s ease, transform 0.4s ease;
           position: relative;
           overflow: hidden;
+          box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
         }
 
         .sheikh-briefing::before {
@@ -228,8 +231,8 @@ export default function PreLessonBriefing({
           top: 0;
           left: 0;
           right: 0;
-          height: 3px;
-          background: linear-gradient(90deg, #2dd496, #28b886, #2dd496);
+          height: 1px;
+          background: linear-gradient(90deg, transparent, rgba(212, 175, 55, 0.4), transparent);
           opacity: 0.8;
         }
 
@@ -242,13 +245,13 @@ export default function PreLessonBriefing({
           display: inline-flex;
           align-items: center;
           gap: 6px;
-          background: rgba(45, 212, 150, 0.1);
-          border: 1px solid rgba(45, 212, 150, 0.2);
+          background: rgba(212, 175, 55, 0.08);
+          border: 1px solid rgba(212, 175, 55, 0.2);
           border-radius: 20px;
           padding: 4px 12px;
           margin-bottom: 14px;
           font-size: 12px;
-          color: #2dd496;
+          color: rgba(212, 175, 55, 0.9);
           letter-spacing: 0.5px;
           text-transform: uppercase;
         }
@@ -268,11 +271,13 @@ export default function PreLessonBriefing({
           width: 40px;
           height: 40px;
           border-radius: 50%;
-          background: linear-gradient(135deg, #2dd496, #1a7a54);
+          background: rgba(255, 255, 255, 0.08);
+          border: 1px solid rgba(212, 175, 55, 0.25);
           display: flex;
           align-items: center;
           justify-content: center;
           flex-shrink: 0;
+          box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
         }
 
         .sheikh-briefing__avatar-emoji {
@@ -288,19 +293,19 @@ export default function PreLessonBriefing({
         .sheikh-briefing__label {
           font-size: 15px;
           font-weight: 600;
-          color: #e8f5f0;
+          color: rgba(255, 255, 255, 0.9);
         }
 
         .sheikh-briefing__subtitle {
           font-size: 12px;
-          color: #6bb89a;
+          color: rgba(255, 255, 255, 0.6);
           margin-top: 1px;
         }
 
         .sheikh-briefing__dismiss {
           background: none;
           border: none;
-          color: #6bb89a;
+          color: rgba(255, 255, 255, 0.5);
           font-size: 16px;
           cursor: pointer;
           padding: 4px 8px;
@@ -310,7 +315,7 @@ export default function PreLessonBriefing({
 
         .sheikh-briefing__dismiss:hover {
           background: rgba(255, 255, 255, 0.05);
-          color: #e8f5f0;
+          color: rgba(255, 255, 255, 0.9);
         }
 
         .sheikh-briefing__body {
@@ -318,7 +323,7 @@ export default function PreLessonBriefing({
         }
 
         .sheikh-briefing__message {
-          color: #c8e6dc;
+          color: rgba(255, 255, 255, 0.8);
           font-size: 14.5px;
           line-height: 1.65;
           margin: 0;
@@ -330,9 +335,9 @@ export default function PreLessonBriefing({
           gap: 8px;
           margin-top: 12px;
           padding: 10px 12px;
-          background: rgba(45, 212, 150, 0.08);
+          background: rgba(255, 255, 255, 0.04);
           border-radius: 10px;
-          border-left: 3px solid #2dd496;
+          border-left: 2px solid rgba(212, 175, 55, 0.4);
         }
 
         .sheikh-briefing__tip-icon {
@@ -342,7 +347,7 @@ export default function PreLessonBriefing({
         }
 
         .sheikh-briefing__tip-text {
-          color: #a8d8c4;
+          color: rgba(255, 255, 255, 0.6);
           font-size: 13.5px;
           line-height: 1.5;
         }
@@ -359,9 +364,9 @@ export default function PreLessonBriefing({
           border-radius: 7px;
           background: linear-gradient(
             90deg,
-            rgba(45, 212, 150, 0.08) 25%,
-            rgba(45, 212, 150, 0.15) 50%,
-            rgba(45, 212, 150, 0.08) 75%
+            rgba(255, 255, 255, 0.04) 25%,
+            rgba(255, 255, 255, 0.08) 50%,
+            rgba(255, 255, 255, 0.04) 75%
           );
           background-size: 200% 100%;
           animation: shimmer 1.5s infinite;


### PR DESCRIPTION
## Summary

Fixes #24 — Practice tab showed generic "Student" greeting for all non-Clerk users.

## Changes

- **`src/app/practice/page.tsx`**: Added `displayName` memo that checks Clerk user → `quranOasis_userName` localStorage (set during onboarding) → fallback. Matches the pattern already used by the dashboard page.
- **`src/app/profile/page.tsx`**: Same localStorage fallback for profile display name.

## Root Cause

The practice and profile pages only checked `user?.firstName` from Clerk auth. When Clerk is unconfigured or user is a guest, this is always `null`, falling back to hardcoded "Student". The dashboard already had the correct pattern of checking `localStorage.getItem("quranOasis_userName")` (set during onboarding flow).

## Note

The review counts and recommendations were already personalized (driven by real SRS spaced-repetition data in localStorage). The issue was specifically the greeting name.