### PR TITLE
fix: show Sheikh HIFZ briefing for all lesson types

### DIFF
--- a/src/app/lessons/[id]/page.tsx
+++ b/src/app/lessons/[id]/page.tsx
@@ -974,47 +974,18 @@ export default function LessonDetailPage() {
     );
   }
   
-  // Show PreLessonBriefing before lesson starts (all lessons get a brief intro)
+  // Show PreLessonBriefing before lesson starts (all lessons get Sheikh briefing)
   if (!lessonStarted) {
-    // For lessons with ayahs, show the full AI-generated briefing
-    if (lessonAyahs.length > 0) {
-      return (
-        <div className="min-h-screen px-4 py-8">
-          <PreLessonBriefing
-            lessonTitle={lesson.title}
-            ayahs={lessonAyahs}
-            userLevel="beginner"
-            isReview={false}
-            onStart={() => setLessonStarted(true)}
-            onDismiss={() => setLessonStarted(true)}
-          />
-        </div>
-      );
-    }
-    // For alphabet/concept lessons without ayahs, show a simple intro card
     return (
-      <div className="min-h-screen px-4 py-8 flex items-center justify-center">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="max-w-md w-full liquid-glass-gold rounded-2xl p-8 text-center"
-        >
-          <div className="w-14 h-14 rounded-2xl bg-gold-500/20 flex items-center justify-center mx-auto mb-4">
-            <BookOpen className="w-7 h-7 text-gold-400" />
-          </div>
-          <h2 className="text-xl font-bold text-night-100 mb-2">{lesson.title}</h2>
-          <p className="text-night-400 text-sm mb-2">Unit {lesson.unit}: {lesson.unitTitle}</p>
-          <p className="text-night-300 text-sm mb-6 leading-relaxed">{lesson.description}</p>
-          <p className="text-night-500 text-xs mb-6">
-            ⏱ About {lesson.estimatedMinutes} minutes · {lesson.xpReward} XP
-          </p>
-          <button
-            onClick={() => setLessonStarted(true)}
-            className="liquid-btn py-3 px-8 text-lg w-full"
-          >
-            Bismillah, Let's Start
-          </button>
-        </motion.div>
+      <div className="min-h-screen px-4 py-8">
+        <PreLessonBriefing
+          lessonTitle={lesson.title}
+          ayahs={lessonAyahs.length > 0 ? lessonAyahs : undefined}
+          userLevel="beginner"
+          isReview={false}
+          onStart={() => setLessonStarted(true)}
+          onDismiss={() => setLessonStarted(true)}
+        />
       </div>
     );
   }

--- a/src/components/PreLessonBriefing.tsx
+++ b/src/components/PreLessonBriefing.tsx
@@ -47,7 +47,7 @@ interface PreLessonBriefingProps {
   /** Lesson title for display */
   lessonTitle: string;
   /** Ayahs the student will study */
-  ayahs: AyahInfo[];
+  ayahs?: AyahInfo[];
   /** User's learning level */
   userLevel: 'beginner' | 'intermediate' | 'advanced';
   /** Whether this is a review lesson */
@@ -77,13 +77,13 @@ export default function PreLessonBriefing({
   const [dismissed, setDismissed] = useState(false);
   const [animateIn, setAnimateIn] = useState(false);
 
+  const safeAyahs = ayahs ?? [];
+
   // Generate briefing on mount
   useEffect(() => {
-    if (ayahs.length === 0) return;
-
     const ctx: BriefingContext = {
       lessonTitle,
-      ayahs,
+      ayahs: safeAyahs,
       userLevel,
       isReview,
     };
@@ -123,7 +123,7 @@ export default function PreLessonBriefing({
   };
 
   const handleLearnMore = () => {
-    const question = briefing
+    const question = briefing && safeAyahs.length > 0
       ? `Tell me more about ${lessonTitle} — what makes these ayahs special?`
       : `What should I know about ${lessonTitle} before I start?`;
     openSheikh(question);


### PR DESCRIPTION
## Summary

All lessons now receive the Sheikh HIFZ briefing via `PreLessonBriefing`, including alphabet/concept lessons without ayahs.

### Changes

- **`PreLessonBriefing`**: Made `ayahs` prop optional. Removed early-return guard on empty ayahs so the AI generates a topic-based briefing for non-ayah lessons. Updated "learn more" prompt for non-ayah context.
- **`page.tsx`**: Removed conditional split that showed a plain card for non-ayah lessons. All lessons now go through `PreLessonBriefing`.

Fixes #19