### PR TITLE
design: upgrade Sheikh HIFZ UI to liquid glass aesthetic

### DIFF
--- a/src/components/PreLessonBriefing.tsx
+++ b/src/components/PreLessonBriefing.tsx
@@ -210,8 +210,10 @@ export default function PreLessonBriefing({
       {/* ─── Styles ──────────────────────────────────────────────── */}
       <style jsx>{`
         .sheikh-briefing {
-          background: linear-gradient(135deg, #0c1f1a 0%, #132e25 50%, #1a3a2f 100%);
-          border: 1px solid rgba(45, 212, 150, 0.15);
+          background: rgba(255, 255, 255, 0.06);
+          backdrop-filter: blur(24px) saturate(1.4);
+          -webkit-backdrop-filter: blur(24px) saturate(1.4);
+          border: 1px solid rgba(255, 255, 255, 0.15);
           border-radius: 16px;
           padding: 20px;
           margin-bottom: 20px;
@@ -220,6 +222,7 @@ export default function PreLessonBriefing({
           transition: opacity 0.4s ease, transform 0.4s ease;
           position: relative;
           overflow: hidden;
+          box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
         }
 
         .sheikh-briefing::before {
@@ -228,8 +231,8 @@ export default function PreLessonBriefing({
           top: 0;
           left: 0;
           right: 0;
-          height: 3px;
-          background: linear-gradient(90deg, #2dd496, #28b886, #2dd496);
+          height: 1px;
+          background: linear-gradient(90deg, transparent, rgba(212, 175, 55, 0.4), transparent);
           opacity: 0.8;
         }
 
@@ -242,13 +245,13 @@ export default function PreLessonBriefing({
           display: inline-flex;
           align-items: center;
           gap: 6px;
-          background: rgba(45, 212, 150, 0.1);
-          border: 1px solid rgba(45, 212, 150, 0.2);
+          background: rgba(212, 175, 55, 0.08);
+          border: 1px solid rgba(212, 175, 55, 0.2);
           border-radius: 20px;
           padding: 4px 12px;
           margin-bottom: 14px;
           font-size: 12px;
-          color: #2dd496;
+          color: rgba(212, 175, 55, 0.9);
           letter-spacing: 0.5px;
           text-transform: uppercase;
         }
@@ -268,7 +271,9 @@ export default function PreLessonBriefing({
           width: 40px;
           height: 40px;
           border-radius: 50%;
-          background: linear-gradient(135deg, #2dd496, #1a7a54);
+          background: rgba(255, 255, 255, 0.08);
+          border: 1px solid rgba(212, 175, 55, 0.25);
+          box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
           display: flex;
           align-items: center;
           justify-content: center;
@@ -288,19 +293,19 @@ export default function PreLessonBriefing({
         .sheikh-briefing__label {
           font-size: 15px;
           font-weight: 600;
-          color: #e8f5f0;
+          color: rgba(255, 255, 255, 0.9);
         }
 
         .sheikh-briefing__subtitle {
           font-size: 12px;
-          color: #6bb89a;
+          color: rgba(255, 255, 255, 0.6);
           margin-top: 1px;
         }
 
         .sheikh-briefing__dismiss {
           background: none;
           border: none;
-          color: #6bb89a;
+          color: rgba(255, 255, 255, 0.6);
           font-size: 16px;
           cursor: pointer;
           padding: 4px 8px;
@@ -310,7 +315,7 @@ export default function PreLessonBriefing({
 
         .sheikh-briefing__dismiss:hover {
           background: rgba(255, 255, 255, 0.05);
-          color: #e8f5f0;
+          color: rgba(255, 255, 255, 0.9);
         }
 
         .sheikh-briefing__body {
@@ -318,7 +323,7 @@ export default function PreLessonBriefing({
         }
 
         .sheikh-briefing__message {
-          color: #c8e6dc;
+          color: rgba(255, 255, 255, 0.8);
           font-size: 14.5px;
           line-height: 1.65;
           margin: 0;
@@ -330,9 +335,9 @@ export default function PreLessonBriefing({
           gap: 8px;
           margin-top: 12px;
           padding: 10px 12px;
-          background: rgba(45, 212, 150, 0.08);
+          background: rgba(255, 255, 255, 0.04);
           border-radius: 10px;
-          border-left: 3px solid #2dd496;
+          border-left: 2px solid rgba(212, 175, 55, 0.4);
         }
 
         .sheikh-briefing__tip-icon {
@@ -342,7 +347,7 @@ export default function PreLessonBriefing({
         }
 
         .sheikh-briefing__tip-text {
-          color: #a8d8c4;
+          color: rgba(255, 255, 255, 0.6);
           font-size: 13.5px;
           line-height: 1.5;
         }
@@ -359,9 +364,9 @@ export default function PreLessonBriefing({
           border-radius: 7px;
           background: linear-gradient(
             90deg,
-            rgba(45, 212, 150, 0.08) 25%,
-            rgba(45, 212, 150, 0.15) 50%,
-            rgba(45, 212, 150, 0.08) 75%
+            rgba(255, 255, 255, 0.04) 25%,
+            rgba(255, 255, 255, 0.08) 50%,
+            rgba(255, 255, 255, 0.04) 75%
           );
           background-size: 200% 100%;
           animation: shimmer 1.5s infinite;

--- a/src/components/ui/SheikhButton.tsx
+++ b/src/components/ui/SheikhButton.tsx
@@ -78,72 +78,74 @@ export default function SheikhButton({
 
         /* ─── Primary ─── */
         .sheikh-btn--primary {
-          background: #1a7a54;
-          color: #fff;
+          background: rgba(255, 255, 255, 0.1);
+          backdrop-filter: blur(16px);
+          -webkit-backdrop-filter: blur(16px);
+          color: rgba(255, 255, 255, 0.9);
+          border: 1px solid rgba(255, 255, 255, 0.15);
           box-shadow:
-            0 0 20px rgba(45, 212, 150, 0.3),
-            0 0 40px rgba(45, 212, 150, 0.1),
+            0 8px 32px rgba(0, 0, 0, 0.25),
             inset 0 1px 0 rgba(255, 255, 255, 0.1);
         }
         .sheikh-btn--primary:hover {
-          background: #1f8e62;
+          background: rgba(255, 255, 255, 0.15);
+          border-color: rgba(212, 175, 55, 0.3);
           box-shadow:
-            0 0 30px rgba(45, 212, 150, 0.5),
-            0 0 60px rgba(45, 212, 150, 0.2);
+            0 8px 32px rgba(0, 0, 0, 0.3),
+            0 0 20px rgba(212, 175, 55, 0.1);
           transform: translateY(-2px);
         }
         .sheikh-btn--primary:active {
           transform: translateY(0);
           box-shadow:
-            0 0 16px rgba(45, 212, 150, 0.3),
-            0 0 32px rgba(45, 212, 150, 0.1);
+            0 4px 16px rgba(0, 0, 0, 0.25);
         }
 
         /* ─── Secondary ─── */
         .sheikh-btn--secondary {
-          background: rgba(45, 212, 150, 0.04);
-          color: #6bb89a;
-          border: 1px solid rgba(45, 212, 150, 0.15);
-          box-shadow: 0 0 12px rgba(45, 212, 150, 0.05);
+          background: rgba(255, 255, 255, 0.04);
+          color: rgba(255, 255, 255, 0.6);
+          border: 1px solid rgba(255, 255, 255, 0.1);
+          box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
         }
         .sheikh-btn--secondary:hover {
-          background: rgba(45, 212, 150, 0.1);
-          color: #2dd496;
-          box-shadow: 0 0 16px rgba(45, 212, 150, 0.15);
-          border-color: rgba(45, 212, 150, 0.25);
+          background: rgba(255, 255, 255, 0.08);
+          color: rgba(255, 255, 255, 0.9);
+          box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+          border-color: rgba(255, 255, 255, 0.2);
         }
         .sheikh-btn--secondary:active {
-          background: rgba(45, 212, 150, 0.14);
+          background: rgba(255, 255, 255, 0.1);
         }
 
         /* ─── Ghost ─── */
         .sheikh-btn--ghost {
           background: transparent;
-          color: #6bb89a;
+          color: rgba(255, 255, 255, 0.5);
           padding-left: 8px;
           padding-right: 8px;
         }
         .sheikh-btn--ghost:hover {
-          color: #2dd496;
-          background: rgba(45, 212, 150, 0.06);
+          color: rgba(255, 255, 255, 0.9);
+          background: rgba(255, 255, 255, 0.06);
         }
 
         /* ─── Chip ─── */
         .sheikh-btn--chip {
-          background: rgba(45, 212, 150, 0.04);
-          border: 1px solid rgba(45, 212, 150, 0.1);
-          color: #7dc4a8;
+          background: rgba(255, 255, 255, 0.04);
+          border: 1px solid rgba(255, 255, 255, 0.1);
+          color: rgba(255, 255, 255, 0.6);
           padding: 7px 14px;
           font-size: 12.5px;
           font-weight: 500;
           border-radius: 20px;
-          box-shadow: 0 0 8px rgba(45, 212, 150, 0.05);
+          box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
         }
         .sheikh-btn--chip:hover {
-          background: rgba(45, 212, 150, 0.1);
-          color: #2dd496;
-          border-color: rgba(45, 212, 150, 0.22);
-          box-shadow: 0 0 12px rgba(45, 212, 150, 0.15);
+          background: rgba(255, 255, 255, 0.08);
+          color: rgba(255, 255, 255, 0.9);
+          border-color: rgba(255, 255, 255, 0.2);
+          box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
           transform: translateY(-1px);
         }
         .sheikh-btn--chip:active {
@@ -157,18 +159,20 @@ export default function SheikhButton({
           border-radius: 50%;
           padding: 0;
           font-size: 22px;
-          background: linear-gradient(145deg, #1a7a54, #22a872);
-          color: #fff;
-          box-shadow:
-            0 0 30px rgba(45, 212, 150, 0.4),
-            0 0 60px rgba(45, 212, 150, 0.15),
-            0 4px 12px rgba(0, 0, 0, 0.2);
+          background: rgba(255, 255, 255, 0.06);
+          backdrop-filter: blur(24px);
+          -webkit-backdrop-filter: blur(24px);
+          border: 1px solid rgba(255, 255, 255, 0.15);
+          color: rgba(255, 255, 255, 0.9);
+          box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
         }
         .sheikh-btn--fab:hover {
           transform: scale(1.12);
+          background: rgba(255, 255, 255, 0.1);
+          border-color: rgba(212, 175, 55, 0.3);
           box-shadow:
-            0 0 40px rgba(45, 212, 150, 0.6),
-            0 0 80px rgba(45, 212, 150, 0.25);
+            0 8px 32px rgba(0, 0, 0, 0.3),
+            0 0 20px rgba(212, 175, 55, 0.1);
         }
         .sheikh-btn--fab:active {
           transform: scale(1.04);
@@ -195,21 +199,18 @@ export default function SheikhButton({
         @keyframes sheikhPulse {
           0%, 100% {
             box-shadow:
-              0 0 20px rgba(45, 212, 150, 0.3),
-              0 0 40px rgba(45, 212, 150, 0.1),
-              0 4px 12px rgba(0, 0, 0, 0.2);
+              0 8px 32px rgba(0, 0, 0, 0.25);
           }
           50% {
             box-shadow:
-              0 0 30px rgba(45, 212, 150, 0.5),
-              0 0 60px rgba(45, 212, 150, 0.2),
-              0 4px 12px rgba(0, 0, 0, 0.2);
+              0 8px 32px rgba(0, 0, 0, 0.3),
+              0 0 16px rgba(212, 175, 55, 0.1);
           }
         }
 
         @keyframes sheikhBreathe {
-          0%, 100% { border-color: rgba(45, 212, 150, 0.1); }
-          50% { border-color: rgba(45, 212, 150, 0.25); }
+          0%, 100% { border-color: rgba(255, 255, 255, 0.1); }
+          50% { border-color: rgba(255, 255, 255, 0.25); }
         }
       `}</style>
     </>


### PR DESCRIPTION
## Summary
Upgrades Sheikh HIFZ floating button and pre-lesson briefing card from solid green design to liquid glass aesthetic.

## Changes
- **PreLessonBriefing.tsx**: Replace solid green card background with frosted glass (`backdrop-blur-xl bg-white/[0.06]`), white glass borders, gold accents for theme badge and tip border, white typography with variable opacity
- **SheikhButton.tsx**: Convert all 5 button variants (primary, secondary, ghost, chip, fab) from solid green to glass-morphism with `backdrop-blur`, white glass borders, deep shadows, and gold hover accents
- **AskSheikhButton.tsx**: Already uses dark glass aesthetic — no changes needed

## Design Principles Applied
- Background: `backdrop-blur-xl bg-white/[0.06]` (frosted glass, never solid)
- Border: `border border-white/[0.15]` (1px white glass edge)
- Shadow: `shadow-[0_8px_32px_rgba(0,0,0,0.25)]`
- Typography: White text with variable opacity (0.9 headers, 0.6 subtitles)
- No solid color backgrounds for cards/containers

Fixes #20