### PR TITLE
fix: use distinct fonts for Naskh and Indo-Pak script options

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,5 @@
 /* Fonts loaded via Next.js font optimization in src/lib/fonts.ts */
-@import url('https://fonts.googleapis.com/css2?family=Noto+Nastaliq+Urdu:wght@400;700&display=swap');
+/* Noto Nastaliq Urdu loaded via next/font/google in fonts.ts */
 
 @tailwind base;
 @tailwind components;
@@ -11,9 +11,9 @@
 :root {
   --font-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   --font-display: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  --font-arabic: var(--font-kitab), 'Amiri Quran', 'Amiri', serif;
-  --font-quran: var(--font-kitab), 'Amiri Quran', 'Amiri', serif;
-  --font-indopak: 'Noto Nastaliq Urdu', 'Jameel Noori Nastaleeq', serif;
+  --font-arabic: var(--font-amiri), 'Amiri Quran', 'Amiri', serif;
+  --font-quran: var(--font-kitab), 'Scheherazade New', serif;
+  --font-indopak: var(--font-nastaliq), 'Noto Nastaliq Urdu', 'Jameel Noori Nastaleeq', serif;
   
   /* Safe Areas */
   --safe-area-top: env(safe-area-inset-top);

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -5,7 +5,7 @@ export const amiri = Amiri({
   weight: ['400', '700'],
   subsets: ['arabic', 'latin'],
   display: 'swap',
-  variable: '--font-arabic',
+  variable: '--font-amiri',
   preload: true,
 });
 
@@ -23,7 +23,7 @@ export const notoNastaliqUrdu = Noto_Nastaliq_Urdu({
   weight: ['400', '500', '600', '700'],
   subsets: ['arabic'],
   display: 'swap',
-  variable: '--font-indopak',
+  variable: '--font-nastaliq',
   preload: false, // Only load when selected
 });
 

--- a/src/lib/preferencesStore.ts
+++ b/src/lib/preferencesStore.ts
@@ -113,7 +113,7 @@ export const ARABIC_FONT_STYLE_OPTIONS: {
     label: 'Indo-Pak', 
     arabicSample: 'بِسْمِ ٱللَّهِ ٱلرَّحْمَٰنِ ٱلرَّحِيمِ',
     description: 'Nastaliq calligraphy style — familiar to readers from Pakistan, India & Bangladesh',
-    fontFamily: "'Noto Nastaliq Urdu', 'Jameel Noori Nastaleeq', serif",
+    fontFamily: "var(--font-indopak)",
   },
 ];
 


### PR DESCRIPTION
## Problem
Both **Hafs Uthmani** and **Naskh** font options resolved to the same font (Scheherazade New via `--font-kitab`), making them visually indistinguishable. Indo-Pak used a redundant CSS `@import` instead of the next/font system.

## Changes
- **Uthmani (Hafs)**: Now uses **Amiri** (`--font-amiri`) — traditional serif style with elegant ligatures
- **Naskh**: Uses **Scheherazade New** (`--font-kitab`) — clean, modern print style (King Fahd Complex aesthetic)
- **Indo-Pak**: Uses **Noto Nastaliq Urdu** via `next/font/google` (`--font-nastaliq`) — proper Nastaliq rendering with optimized loading
- Removed redundant Google Fonts CSS import (font already loaded via next/font)
- All three script options are now visually distinct

## Files Changed
- `src/app/globals.css` — Updated CSS custom property fallback chains
- `src/lib/fonts.ts` — Renamed CSS variables for Amiri and Nastaliq fonts
- `src/lib/preferencesStore.ts` — Indo-Pak option uses CSS variable instead of hardcoded font stack

Fixes #13