### PR TITLE
fix: resolve Arabic letter display overlap in lesson slides

### DIFF
--- a/src/app/lessons/[id]/page.tsx
+++ b/src/app/lessons/[id]/page.tsx
@@ -259,13 +259,13 @@ function ArabicDisplay({
         }} />
       </div>
       
-      <div className="relative p-8 flex flex-col items-center justify-center min-h-[160px]">
+      <div className="relative p-8 flex flex-col items-center justify-center min-h-[200px]">
         {/* Main Arabic text */}
         <div
           className={`
             font-arabic text-center
             ${isSingleLetter
-              ? 'text-8xl sm:text-9xl text-gold-400 drop-shadow-[0_0_20px_rgba(201,162,39,0.3)] leading-none pb-4'
+              ? 'text-8xl sm:text-9xl text-gold-400 drop-shadow-[0_0_20px_rgba(201,162,39,0.3)] leading-relaxed pb-2'
               : isWord
                 ? 'text-5xl sm:text-6xl text-gold-300 leading-tight'
                 : 'text-3xl sm:text-4xl text-night-100 leading-relaxed'
@@ -282,7 +282,7 @@ function ArabicDisplay({
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.2 }}
-            className="mt-4 pt-4 flex flex-col items-center gap-1 text-center border-t border-night-700/50"
+            className="mt-6 pt-4 flex flex-col items-center gap-2 text-center border-t border-night-700/50"
           >
             <span className="text-xl font-semibold text-gold-400">{letterData.name}</span>
             <span className="text-sm font-mono text-night-400 tracking-wide">/{letterData.phonetic}/</span>


### PR DESCRIPTION
## Problem
In letter explanation slides, the Arabic letter display card shows the romanized name overlapping with the Arabic character and phonetic transcription due to `leading-none` on large text sizes.

## Changes
- Change `leading-none` to `leading-relaxed` on Arabic letter text (`text-8xl`/`text-9xl`) to prevent character overflow
- Increase margin between Arabic character and name/phonetic section (`mt-4` → `mt-6`, `gap-1` → `gap-2`)
- Increase container `min-height` from 160px to 200px

Fixes #10