### PR TITLE
fix: restyle reciter toast to match liquid glass design system

### DIFF
--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -49,20 +49,20 @@ export function useToast() {
   return context;
 }
 
-// Toast icons by type
+// Toast icons by type — gold accent for success/info, contextual for error/warning
 const TOAST_ICONS: Record<ToastType, ReactNode> = {
-  success: <CheckCircle2 className="w-5 h-5 text-sage-400" />,
+  success: <CheckCircle2 className="w-5 h-5 text-gold-400" />,
   error: <AlertCircle className="w-5 h-5 text-red-400" />,
-  info: <Info className="w-5 h-5 text-blue-400" />,
+  info: <Info className="w-5 h-5 text-gold-400" />,
   warning: <AlertCircle className="w-5 h-5 text-amber-400" />,
 };
 
-// Toast styles by type
+// Toast styles — dark glass-morphism with gold accent border
 const TOAST_STYLES: Record<ToastType, string> = {
-  success: 'border-sage-500/30 bg-sage-500/10',
-  error: 'border-red-500/30 bg-red-500/10',
-  info: 'border-blue-500/30 bg-blue-500/10',
-  warning: 'border-amber-500/30 bg-amber-500/10',
+  success: 'border-gold-500/30',
+  error: 'border-red-500/30',
+  info: 'border-gold-500/30',
+  warning: 'border-amber-500/30',
 };
 
 export function ToastProvider({ children }: { children: ReactNode }) {
@@ -154,8 +154,8 @@ function ToastItem({ toast, removeToast }: { toast: Toast; removeToast: (id: str
       className={`
         pointer-events-auto relative overflow-hidden
         flex items-center gap-3 px-4 py-3 rounded-xl
-        bg-night-900/95 backdrop-blur-lg border
-        shadow-lg shadow-black/20
+        bg-night-900/90 backdrop-blur-xl border
+        shadow-lg shadow-black/30
         ${TOAST_STYLES[toast.type]}
       `}
     >


### PR DESCRIPTION
## Changes

Restyled the toast notification component to match the site's dark luxury / liquid glass design system.

### Before
- Success toasts used green sage accent (`border-sage-500/30 bg-sage-500/10`)
- Info toasts used blue accent (`border-blue-500/30 bg-blue-500/10`)
- Icons used sage/blue colors

### After
- All success/info toasts use gold accent border (`border-gold-500/30`) matching the site's gold design language
- Dark glass-morphism background: `bg-night-900/90 backdrop-blur-xl`
- Gold check/info icons (`text-gold-400`)
- Error/warning toasts retain contextual red/amber colors

Fixes #12