### PR TITLE
fix: personalize profile greeting and reflect user preferences

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -196,8 +196,16 @@ export default function ProfilePage() {
     };
   }, []);
 
-  // Get user info
-  const displayName = user?.firstName || 'Student of Quran';
+  // Get user info — resolve name: Clerk firstName → localStorage userName → fallback
+  const [displayName, setDisplayName] = useState('Student of Quran');
+  useEffect(() => {
+    if (user?.firstName) {
+      setDisplayName(user.firstName);
+    } else if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('quranOasis_userName');
+      if (stored) setDisplayName(stored);
+    }
+  }, [user]);
   const email = user?.emailAddresses?.[0]?.emailAddress;
   const avatarUrl = user?.imageUrl;
   const joinedDate = user?.createdAt 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1237,10 +1237,10 @@ Additional Notes:
                 <span className="text-night-400">Reciter:</span> {RECITERS.find(r => r.id === preferences.audio.reciter)?.name || 'Mishary Rashid Alafasy'}
               </p>
               <p className="text-night-500">
-                <span className="text-night-400">Audio:</span> EveryAyah.com
+                <span className="text-night-400">Audio:</span> EveryAyah.com ({RECITERS.find(r => r.id === preferences.audio.reciter)?.name || 'Default'})
               </p>
               <p className="text-night-500">
-                <span className="text-night-400">Text:</span> Tanzil.net
+                <span className="text-night-400">Text:</span> Tanzil.net ({ARABIC_FONT_STYLE_OPTIONS.find(f => f.value === preferences.display.arabicFontStyle)?.label || 'Default'})
               </p>
             </div>
           </GlassPanel>


### PR DESCRIPTION
## Changes

1. **Profile page**: Display name now resolves via Clerk `user.firstName` → `localStorage quranOasis_userName` → fallback "Student of Quran", so logged-in users see a personalized greeting.

2. **Settings About section**: Audio and Text lines now dynamically show the user's selected reciter name (from `RECITERS`) and Arabic script style (from `ARABIC_FONT_STYLE_OPTIONS`) instead of hardcoded generic strings.

Fixes #15