### PR TITLE
fix: tighten excessive top nav spacing across pages

### DIFF
--- a/src/app/lessons/[id]/page.tsx
+++ b/src/app/lessons/[id]/page.tsx
@@ -977,7 +977,7 @@ export default function LessonDetailPage() {
   // Show PreLessonBriefing before lesson starts (all lessons get Sheikh HIFZ briefing)
   if (!lessonStarted) {
     return (
-      <div className="min-h-screen px-4 py-8">
+      <div className="min-h-screen px-4 py-4">
         <PreLessonBriefing
           lessonTitle={lesson.title}
           ayahs={lessonAyahs}
@@ -1027,7 +1027,7 @@ export default function LessonDetailPage() {
       </AnimatePresence>
 
       {/* Header - Premium Frosted Glass */}
-      <header className="sticky top-0 z-40 safe-area-top liquid-glass mx-2 mt-2 rounded-2xl">
+      <header className="sticky top-0 z-40 safe-area-top liquid-glass mx-2 rounded-2xl">
         <div className="flex items-center justify-between px-3 py-3">
           <button 
             onClick={() => router.push('/lessons')} 

--- a/src/app/lessons/page.tsx
+++ b/src/app/lessons/page.tsx
@@ -560,7 +560,7 @@ function LessonsContent() {
     <div className="min-h-screen">
       {/* Header - Premium Frosted Glass */}
       <header 
-        className="sticky top-0 z-40 safe-area-top liquid-glass mx-2 mt-2 rounded-2xl"
+        className="sticky top-0 z-40 safe-area-top liquid-glass mx-2 rounded-2xl"
       >
         <div className="flex items-center justify-between px-3 py-3">
           <Link href="/" className="liquid-icon-btn" aria-label="Back to home">

--- a/src/app/memorize/loading.tsx
+++ b/src/app/memorize/loading.tsx
@@ -7,7 +7,7 @@ export default function MemorizeLoading() {
   return (
     <div className="min-h-screen bg-night-950">
       {/* Header skeleton */}
-      <header className="sticky top-0 z-40 safe-area-top liquid-glass rounded-b-2xl mx-2 mt-2">
+      <header className="sticky top-0 z-40 safe-area-top liquid-glass rounded-b-2xl mx-2">
         <div className="px-3 py-3">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">

--- a/src/app/memorize/page.tsx
+++ b/src/app/memorize/page.tsx
@@ -29,7 +29,7 @@ export default function MemorizePage() {
   return (
     <div className="min-h-screen">
       {/* Header */}
-      <header className="sticky top-0 z-40 safe-area-top liquid-glass mx-2 mt-2 rounded-2xl">
+      <header className="sticky top-0 z-40 safe-area-top liquid-glass mx-2 rounded-2xl">
         <div className="px-4 py-3 flex items-center gap-3">
           <Link href={backHref} className="liquid-icon-btn">
             <ChevronLeft className="w-5 h-5" />

--- a/src/app/mushaf/loading.tsx
+++ b/src/app/mushaf/loading.tsx
@@ -8,7 +8,7 @@ export default function MushafLoading() {
     <div className="min-h-screen">
       {/* Header skeleton - Premium frosted glass style */}
       <header 
-        className="sticky top-0 z-40 safe-area-top mx-2 mt-2 rounded-2xl overflow-hidden"
+        className="sticky top-0 z-40 safe-area-top mx-2 rounded-2xl overflow-hidden"
         style={{
           background: 'rgba(22, 27, 34, 0.72)',
           backdropFilter: 'blur(48px)',

--- a/src/app/mushaf/page.tsx
+++ b/src/app/mushaf/page.tsx
@@ -364,7 +364,7 @@ export default function MushafPage() {
         animate={{ y: 0, opacity: 1 }}
         exit={{ y: -100, opacity: 0 }}
         transition={{ duration: 0.25 }}
-        className="sticky top-0 z-40 safe-area-top liquid-glass glass-noise rounded-b-2xl mx-2 mt-2"
+        className="sticky top-0 z-40 safe-area-top liquid-glass glass-noise rounded-b-2xl mx-2"
       >
             <div className="flex items-center justify-between px-3 py-3">
               <div className="flex items-center gap-1.5">

--- a/src/app/practice/flashcards/page.tsx
+++ b/src/app/practice/flashcards/page.tsx
@@ -135,7 +135,7 @@ export default function FlashcardsPage() {
   return (
     <div className="min-h-screen">
       {/* Header */}
-      <header className="sticky top-0 z-40 safe-area-top liquid-glass mx-2 mt-2 rounded-2xl">
+      <header className="sticky top-0 z-40 safe-area-top liquid-glass mx-2 rounded-2xl">
         <div className="flex items-center justify-between px-3 py-3">
           <Link href="/practice" className="liquid-icon-btn" aria-label="Back">
             <ChevronLeft className="w-5 h-5" />

--- a/src/app/practice/loading.tsx
+++ b/src/app/practice/loading.tsx
@@ -19,7 +19,7 @@ export default function PracticeLoading() {
 
       {/* Header skeleton - Frosted glass style */}
       <header 
-        className="sticky top-0 z-40 safe-area-top mx-2 mt-2 rounded-2xl overflow-hidden"
+        className="sticky top-0 z-40 safe-area-top mx-2 rounded-2xl overflow-hidden"
         style={{
           background: 'rgba(22, 27, 34, 0.72)',
           backdropFilter: 'blur(48px)',

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -216,7 +216,7 @@ export default function ProfilePage() {
     <div className="min-h-screen bg-night-950">
       {/* Header - Premium Frosted Glass */}
       <header 
-        className="sticky top-0 z-40 safe-area-top liquid-glass mx-2 mt-2 rounded-2xl"
+        className="sticky top-0 z-40 safe-area-top liquid-glass mx-2 rounded-2xl"
       >
         <div className="flex items-center justify-between px-3 py-3">
           <Link href="/" className="liquid-icon-btn">

--- a/src/app/progress/page.tsx
+++ b/src/app/progress/page.tsx
@@ -469,7 +469,7 @@ export default function ProgressPage() {
   return (
     <div className="min-h-screen">
       {/* Header */}
-      <header className="sticky top-0 z-40 safe-area-top liquid-glass mx-2 mt-2 rounded-2xl">
+      <header className="sticky top-0 z-40 safe-area-top liquid-glass mx-2 rounded-2xl">
         <div className="flex items-center justify-between px-3 py-3">
           <Link href="/profile" className="liquid-icon-btn">
             <ChevronLeft className="w-5 h-5" />

--- a/src/app/recite/loading.tsx
+++ b/src/app/recite/loading.tsx
@@ -7,7 +7,7 @@ export default function ReciteLoading() {
   return (
     <div className="min-h-screen bg-night-950">
       {/* Header skeleton */}
-      <header className="sticky top-0 z-40 safe-area-top liquid-glass rounded-b-2xl mx-2 mt-2">
+      <header className="sticky top-0 z-40 safe-area-top liquid-glass rounded-b-2xl mx-2">
         <div className="px-3 py-3">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">

--- a/src/app/techniques/page.tsx
+++ b/src/app/techniques/page.tsx
@@ -40,7 +40,7 @@ export default function MemorizationTechniquesPage() {
   return (
     <div className="min-h-screen">
       {/* Header - Liquid Glass */}
-      <header className="sticky top-0 z-40 safe-area-top liquid-glass mx-2 mt-2 rounded-2xl">
+      <header className="sticky top-0 z-40 safe-area-top liquid-glass mx-2 rounded-2xl">
         <div className="flex items-center justify-between px-4 py-3">
           <Link href="/dashboard" className="liquid-icon-btn">
             <ChevronLeft className="w-5 h-5" />


### PR DESCRIPTION
## Changes

- Remove `mt-2` from all `safe-area-top` headers across 12 pages (lessons, profile, progress, memorize, mushaf, practice, techniques, recite + loading states)
- Change `py-8` to `py-4` on pre-briefing section in `lessons/[id]/page.tsx`
- `safe-area-top` in globals.css already uses `max(0.5rem,...)` — no change needed there

Fixes #16