### PR TITLE
fix: show Sheikh HIFZ briefing for all lesson types

### DIFF
--- a/src/app/lessons/[id]/page.tsx
+++ b/src/app/lessons/[id]/page.tsx
@@ -980,7 +980,7 @@ export default function LessonDetailPage() {
       <div className="min-h-screen px-4 py-8">
         <PreLessonBriefing
           lessonTitle={lesson.title}
-          ayahs={lessonAyahs}
+          ayahs={lessonAyahs.length > 0 ? lessonAyahs : undefined}
           userLevel="beginner"
           isReview={false}
           lessonDescription={lesson.description}

--- a/src/components/PreLessonBriefing.tsx
+++ b/src/components/PreLessonBriefing.tsx
@@ -47,7 +47,7 @@ interface PreLessonBriefingProps {
   /** Lesson title for display */
   lessonTitle: string;
   /** Ayahs the student will study */
-  ayahs: AyahInfo[];
+  ayahs?: AyahInfo[];
   /** User's learning level */
   userLevel: 'beginner' | 'intermediate' | 'advanced';
   /** Whether this is a review lesson */
@@ -89,19 +89,13 @@ export default function PreLessonBriefing({
   const [briefing, setBriefing] = useState<BriefingResponse | null>(null);
   const [dismissed, setDismissed] = useState(false);
   const [animateIn, setAnimateIn] = useState(false);
+  const safeAyahs = ayahs ?? [];
 
   // Generate briefing on mount
   useEffect(() => {
-    // For non-ayah lessons, use a static motivational briefing
-    if (ayahs.length === 0) {
-      setBriefing(getStaticBriefing(lessonTitle, lessonDescription));
-      requestAnimationFrame(() => setAnimateIn(true));
-      return;
-    }
-
     const ctx: BriefingContext = {
       lessonTitle,
-      ayahs,
+      ayahs: safeAyahs,
       userLevel,
       isReview,
     };
@@ -142,7 +136,9 @@ export default function PreLessonBriefing({
 
   const handleLearnMore = () => {
     const question = briefing
-      ? `Tell me more about ${lessonTitle} — what makes these ayahs special?`
+      ? (safeAyahs.length > 0
+          ? `Tell me more about ${lessonTitle} — what makes these ayahs special?`
+          : `Tell me more about ${lessonTitle} — what should I focus on?`)
       : `What should I know about ${lessonTitle} before I start?`;
     openSheikh(question);
   };


### PR DESCRIPTION
Fixes #19

**Changes:**
- `PreLessonBriefing.tsx`: Made `ayahs` prop optional, replaced early return for empty ayahs with unified AI briefing path, adjusted `handleLearnMore` question for non-ayah lessons
- `lessons/[id]/page.tsx`: Pass `undefined` instead of empty array for lessons without ayahs

All lesson types now get the full Sheikh HIFZ briefing experience.