### PR TITLE
fix: Sheikh HIFZ modal drag handle and back button navigation

### DIFF
--- a/src/app/mushaf/page.tsx
+++ b/src/app/mushaf/page.tsx
@@ -368,9 +368,9 @@ export default function MushafPage() {
       >
             <div className="flex items-center justify-between px-3 py-3">
               <div className="flex items-center gap-1.5">
-                <Link href="/" className="liquid-icon-btn">
+                <button onClick={() => router.back()} className="liquid-icon-btn">
                   <ChevronLeft className="w-5 h-5" />
-                </Link>
+                </button>
                 <button onClick={() => setShowSurahList(true)} className="liquid-icon-btn">
                   <List className="w-5 h-5" />
                 </button>

--- a/src/components/SheikhChat.tsx
+++ b/src/components/SheikhChat.tsx
@@ -26,8 +26,9 @@ import { MosqueIcon, BookReadIcon } from '@/components/icons';
  *   <SheikhChat ayahContext={...} userLevel="intermediate" />
  */
 
-import { useState, useRef, useEffect, useCallback, type FormEvent, type KeyboardEvent } from 'react';
+import { useState, useRef, useEffect, useCallback, type FormEvent, type KeyboardEvent, type TouchEvent as ReactTouchEvent } from 'react';
 import { motion, AnimatePresence, useMotionValue, useTransform, useAnimation, PanInfo } from 'framer-motion';
+import { useRouter } from 'next/navigation';
 import { useSheikhChat, type AyahContext, type ChatMessage } from '@/hooks/useSheikhChat';
 import { useSheikh } from '@/contexts/SheikhContext';
 import { usePremium } from '@/contexts/PremiumContext';
@@ -205,6 +206,64 @@ function QuestionChip({ question, onClick, delay }: { question: string; onClick:
     >
       {question}
     </motion.button>
+  );
+}
+
+// ─── Drag Handle (touch-aware) ───────────────────────────────────────
+function DragHandle({ onClose }: { onClose: () => void }) {
+  const startY = useRef(0);
+  const currentY = useRef(0);
+  const handleRef = useRef<HTMLDivElement>(null);
+
+  const onTouchStart = (e: ReactTouchEvent) => {
+    startY.current = e.touches[0].clientY;
+    currentY.current = 0;
+  };
+
+  const onTouchMove = (e: ReactTouchEvent) => {
+    const delta = e.touches[0].clientY - startY.current;
+    if (delta < 0) return; // only allow downward drag
+    currentY.current = delta;
+    // Translate the entire panel container
+    const panel = handleRef.current?.closest('[role="dialog"]') as HTMLElement | null;
+    if (panel) {
+      panel.style.transform = `translateY(${delta}px)`;
+      panel.style.transition = 'none';
+    }
+  };
+
+  const onTouchEnd = () => {
+    const panel = handleRef.current?.closest('[role="dialog"]') as HTMLElement | null;
+    if (currentY.current > 100) {
+      // Dismiss
+      if (panel) {
+        panel.style.transition = 'transform 0.2s ease-out';
+        panel.style.transform = 'translateY(100%)';
+      }
+      setTimeout(onClose, 200);
+    } else {
+      // Snap back
+      if (panel) {
+        panel.style.transition = 'transform 0.2s ease-out';
+        panel.style.transform = 'translateY(0)';
+      }
+    }
+    currentY.current = 0;
+  };
+
+  return (
+    <div
+      ref={handleRef}
+      onTouchStart={onTouchStart}
+      onTouchMove={onTouchMove}
+      onTouchEnd={onTouchEnd}
+      onClick={onClose}
+      className="w-full py-3 flex justify-center cursor-pointer touch-none"
+      role="button"
+      aria-label="Drag down or tap to close Sheikh chat panel"
+    >
+      <div className="w-10 h-1 bg-white/25 rounded-full" />
+    </div>
   );
 }
 
@@ -426,21 +485,24 @@ export default function SheikhChat({
           <span aria-hidden="true" className="pointer-events-none absolute inset-0 z-[1]"
             style={{ backgroundImage: "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.80' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E\")", opacity: 0.038, mixBlendMode: 'overlay' as const }}
           />
-          {/* Drag handle — tappable close target */}
+          {/* Drag handle — touch-aware drag to dismiss */}
           {mode === 'panel' && onClose && (
-            <button
-              onClick={onClose}
-              className="w-full py-2 flex justify-center cursor-pointer focus:outline-none"
-              aria-label="Close Sheikh chat panel"
-            >
-              <div className="w-10 h-1 bg-white/25 rounded-full" />
-            </button>
+            <DragHandle onClose={onClose} />
           )}
 
           {/* Header */}
           <div className="flex items-center justify-between px-5 py-3.5 border-b border-white/5">
 
             <div className="flex items-center gap-3">
+              {onClose && (
+                <button
+                  onClick={onClose}
+                  className="w-9 h-9 rounded-full flex items-center justify-center text-night-400 hover:text-white hover:bg-white/10 transition-all focus:ring-2 focus:ring-gold-500/50 focus:outline-none"
+                  aria-label="Go back"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5"><path d="M15 18l-6-6 6-6"/></svg>
+                </button>
+              )}
               <div className="w-9 h-9 rounded-full bg-gold-500/15 flex items-center justify-center">
                 <MosqueIcon size={20} aria-hidden="true" />
               </div>


### PR DESCRIPTION
## Summary

Fixes three navigation issues reported in #25:

1. **Sheikh HIFZ modal drag handle frozen** — Replaced static `<button>` drag handle with a touch-aware `DragHandle` component using `onTouchStart/Move/End`. The panel translates on drag and dismisses when dragged >100px down.

2. **Back button broken in Sheikh modal** — Added a back chevron button in the header next to the mosque icon that calls `onClose`.

3. **Back button broken in mushaf page** — Changed the back button from `<Link href="/">` to `<button onClick={() => router.back()}>` so it properly navigates back in browser history.

## Files Changed
- `src/components/SheikhChat.tsx` — New `DragHandle` component + back chevron in header
- `src/app/mushaf/page.tsx` — Back button uses `router.back()`

Fixes pagodahut/quran-oasis#25